### PR TITLE
re-enable redering w/o context

### DIFF
--- a/.github/workflows/sesam-community-ci-cd.yml
+++ b/.github/workflows/sesam-community-ci-cd.yml
@@ -1,6 +1,18 @@
 name: SesamCommunity CI&CD
 
-on: [push, pull_request, release]
+on:
+  pull_request:
+  push:
+    paths-ignore:
+      - '**.md'
+      - '**.rst'
+    branches:
+      - '**'
+    tags-ignore:
+      - '**'
+  release:
+    types: [published]
+
 
 jobs:
   build:
@@ -8,6 +20,7 @@ jobs:
 
     steps:
       - name: Docker Login
+        if: startsWith( github.ref, 'refs/tags/') == true || startsWith(github.ref, 'refs/heads/master') == true
         uses: docker/login-action@v1.8.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -24,6 +37,6 @@ jobs:
           GITHUB_SHA: ${{ github.sha }}
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          # DOCKER_REPO_NAME: uncomment_and_set_to_docker_repo_name
+          # DOCKER_REPO_NAME: uncomment_and_set_to_docker_repo_name_if_different_from_github_repoa_name
         run: bash <(curl -s https://raw.githubusercontent.com/sesam-community/guidelines/master/git_action.sh)
         shell: bash

--- a/service/transform-service.py
+++ b/service/transform-service.py
@@ -15,7 +15,7 @@ app = Flask(__name__)
 
 PORT = int(os.environ.get("PORT", 5001))
 
-logger = sesam_logger("rest-transform-service")
+logger = sesam_logger("rest-transform-service", app=app)
 
 prop = os.environ.get("PROPERTY", "response")
 payload_property = os.environ.get("PAYLOAD_PROPERTY_FOR_TRANSFORM_REQUEST", "payload")


### PR DESCRIPTION
- Handle url rendering with 'entity' context(deprecated) and with no context at all - to keep backward compatibility
- enable access logging
- updated README